### PR TITLE
Set width and height to the CC BY image.

### DIFF
--- a/skins/WebPlatform.php
+++ b/skins/WebPlatform.php
@@ -277,7 +277,7 @@ class WebPlatformTemplate extends BaseTemplate {
 		  <div class="container">
 			 <div id="footer-wordmark">
 				<a href="/wiki/Template:CC-by-3.0" class="license">
-				  <img src="/w/skins/webplatform/images/cc-by-black.svg"
+				  <img src="/w/skins/webplatform/images/cc-by-black.svg" width="120" height="42"
 						 alt="Content available under CC-BY, except where otherwise noted.">
 				</a>
 


### PR DESCRIPTION
Best practices say that every image element should have explicit width and height. Since the CSS never changes them (and even if it does, it would override those defined in the HTML, so it does not break anything), we can just set them inline.
